### PR TITLE
CNDE-2951 Changing key_column for 'CASE_LAB_DATAMART'  table from "INVESTIGATION_KEY" to "INVESTIGATION_LOCAL_ID"

### DIFF
--- a/DataCompareAPIs/src/main/resources/sql/dataCompareDataGeneration.sql
+++ b/DataCompareAPIs/src/main/resources/sql/dataCompareDataGeneration.sql
@@ -1312,7 +1312,7 @@ values ('D_PATIENT', 'RDB', 'RDB_MODERN',
                                       WHERE RowNum BETWEEN :startRow AND :endRow;',
        		'SELECT COUNT(*)
                                       FROM CASE_LAB_DATAMART;',
-       		'INVESTIGATION_KEY',
+       		'INVESTIGATION_LOCAL_ID',
        		'RowNum, INVESTIGATION_KEY',
        		1
        		),


### PR DESCRIPTION
Modifying DataCompare configuration for table ''CASE_LAB_DATAMART' . Setting key_column as "INVESTIGATION_LOCAL_ID"