### PR TITLE
CNDE-2957 LAB_RESULT_COMMENT. Data compare should  ignore key fields [“LAB_RESULT_COMMENT_KEY“, “RESULT_COMMENT_GRP_KEY“]

### DIFF
--- a/DataCompareAPIs/src/main/resources/sql/dataCompareDataGeneration.sql
+++ b/DataCompareAPIs/src/main/resources/sql/dataCompareDataGeneration.sql
@@ -826,7 +826,7 @@ values ('D_PATIENT', 'RDB', 'RDB_MODERN',
        		'SELECT COUNT(*)
                                       FROM LAB_RESULT_COMMENT;',
        		'LAB_TEST_UID',
-       		'RowNum, LAB_TEST_UID',
+       		'RowNum, LAB_TEST_UID, LAB_RESULT_COMMENT_KEY, RESULT_COMMENT_GRP_KEY',
        		1
        		),
        	(


### PR DESCRIPTION
Data compare should  ignore key fields [“LAB_RESULT_COMMENT_KEY“, “RESULT_COMMENT_GRP_KEY“] for table LAB_RESULT_COMMENT