### PR TITLE
CNDE-2958  Data Compare Adding keys [“TEST_RESULT_GRP_KEY", "TEST_RESULT_VAL_KEY“] and RDB_LAST_REFRESH_TIME to ignore field list for table LAB_RESULT_VAL

### DIFF
--- a/DataCompareAPIs/src/main/resources/sql/dataCompareDataGeneration.sql
+++ b/DataCompareAPIs/src/main/resources/sql/dataCompareDataGeneration.sql
@@ -826,7 +826,7 @@ values ('D_PATIENT', 'RDB', 'RDB_MODERN',
        		'SELECT COUNT(*)
                                       FROM LAB_RESULT_COMMENT;',
        		'LAB_TEST_UID',
-       		'RowNum, LAB_TEST_UID, LAB_RESULT_COMMENT_KEY, RESULT_COMMENT_GRP_KEY',
+       		'RowNum, LAB_TEST_UID, LAB_RESULT_COMMENT_KEY, RESULT_COMMENT_GRP_KEY, RDB_LAST_REFRESH_TIME',
        		1
        		),
        	(
@@ -844,7 +844,7 @@ values ('D_PATIENT', 'RDB', 'RDB_MODERN',
        		'SELECT COUNT(*)
                                       FROM LAB_RESULT_VAL;',
        		'LAB_TEST_UID',
-       		'RowNum, LAB_TEST_UID',
+       		'RowNum, LAB_TEST_UID, TEST_RESULT_GRP_KEY, TEST_RESULT_VAL_KEY, RDB_LAST_REFRESH_TIME',
        		1
        		),
        	(


### PR DESCRIPTION
Ticket https://cdc-nbs.atlassian.net/browse/CNDE-2958

Data compare should ignore key fields [“TEST_RESULT_GRP_KEY", "TEST_RESULT_VAL_KEY“] and RDB_LAST_REFRESH_TIME. This last field “RDB_LAST_REFRESH_TIME“ is set in stored procedure using function GETDATE(), so it will never match with value in RDB