### PR TITLE
CNDE-2967 Data Compare Tool - LAB100. Data compare should ignore key fields [“RESULTED_LAB_TEST_KEY", "INVESTIGATION_KEYS“] and RDB_LAST_REFRESH_TIME

### DIFF
--- a/DataCompareAPIs/src/main/resources/sql/dataCompareDataGeneration.sql
+++ b/DataCompareAPIs/src/main/resources/sql/dataCompareDataGeneration.sql
@@ -862,7 +862,7 @@ values ('D_PATIENT', 'RDB', 'RDB_MODERN',
        		'SELECT COUNT(*)
                                       FROM LAB100;',
        		'LAB_RPT_LOCAL_ID',
-       		'RowNum, LAB_RPT_LOCAL_ID',
+       		'RowNum, LAB_RPT_LOCAL_ID, RESULTED_LAB_TEST_KEY, INVESTIGATION_KEYS, RDB_LAST_REFRESH_TIME',
        		1
        		),
        	(


### PR DESCRIPTION
Ticket: https://cdc-nbs.atlassian.net/browse/CNDE-2967

Data Compare Tool - LAB100. Data compare should ignore key fields [“RESULTED_LAB_TEST_KEY", "INVESTIGATION_KEYS“] and RDB_LAST_REFRESH_TIME