### PR TITLE
CNDE-2974 Ignoring key RESULTED_LAB_TEST_KEY and  RDB_LAST_REFRESH_TIME . Adding LAB_RPT_LOCAL_ID as key column

### DIFF
--- a/DataCompareAPIs/src/main/resources/sql/dataCompareDataGeneration.sql
+++ b/DataCompareAPIs/src/main/resources/sql/dataCompareDataGeneration.sql
@@ -879,8 +879,8 @@ values ('D_PATIENT', 'RDB', 'RDB_MODERN',
                                       WHERE RowNum BETWEEN :startRow AND :endRow;',
        		'SELECT COUNT(*)
                                       FROM LAB101;',
-       		'RESULTED_LAB_TEST_KEY',
-       		'RowNum, RESULTED_LAB_TEST_KEY',
+       		'LAB_RPT_LOCAL_ID',
+       		'RowNum, LAB_RPT_LOCAL_ID, RESULTED_LAB_TEST_KEY, RDB_LAST_REFRESH_TIME',
        		1
        		),
        	(


### PR DESCRIPTION
Ticket (https://cdc-nbs.atlassian.net/browse/CNDE-2974)

Data Compare Tool - LAB101. Data compare should ignore key field “RESULTED_LAB_TEST_KEY", "RDB_LAST_REFRESH_TIME" and use LAB_RPT_LOCAL_ID  as key column