### PR TITLE
CNDE-2994 Modify column key to compare TB_DATAMART and TB_HIV_DATAMART

### DIFF
--- a/DataCompareAPIs/src/main/resources/sql/dataCompareDataGeneration.sql
+++ b/DataCompareAPIs/src/main/resources/sql/dataCompareDataGeneration.sql
@@ -2050,8 +2050,8 @@ values ('D_PATIENT', 'RDB', 'RDB_MODERN',
                                       WHERE RowNum BETWEEN :startRow AND :endRow;',
        		'SELECT COUNT(*)
                                       FROM TB_DATAMART;',
-       		'INVESTIGATION_KEY',
-       		'RowNum, INVESTIGATION_KEY',
+       		'INVESTIGATION_LOCAL_ID',
+       		'RowNum, INVESTIGATION_LOCAL_ID, INVESTIGATION_KEY',
        		1
        		),
        	(
@@ -2068,8 +2068,8 @@ values ('D_PATIENT', 'RDB', 'RDB_MODERN',
                                       WHERE RowNum BETWEEN :startRow AND :endRow;',
        		'SELECT COUNT(*)
                                       FROM TB_HIV_DATAMART;',
-       		'INVESTIGATION_KEY',
-       		'RowNum, INVESTIGATION_KEY',
+       		'INVESTIGATION_LOCAL_ID',
+       		'RowNum, INVESTIGATION_LOCAL_ID, INVESTIGATION_KEY',
        		1
        		),
        	(


### PR DESCRIPTION
Ticket (https://cdc-nbs.atlassian.net/browse/CNDE-2994)

Data Compare Tool - TB_DATAMART and TB_HIV_DATAMART must  use INVESTIGATION_LOCAL_ID as key_column. Now both tables are configured using INVESTIGATION_KEY but we can’t guarantee key is the same in both databases (RDB, RDB_MODERN)