### PR TITLE
Minor updates to fix Data Compare results

### DIFF
--- a/DataCompareAPIs/src/main/resources/db/data_internal/routines/001-generate-data.sql
+++ b/DataCompareAPIs/src/main/resources/db/data_internal/routines/001-generate-data.sql
@@ -2230,7 +2230,7 @@ values
            'SELECT COUNT(*)
                                   FROM MEASLES_CASE;',
            'CASE_UID',
-           'RowNum,INVESTIGATION_KEY,CONDITION_KEY,PATIENT_KEY,INVESTIGATOR_KEY,PHYSICIAN_KEY,REPORTER_KEY,RPT_SRC_ORG_KEY,ADT_HSPTL_KEY,INV_ASSIGNED_DT_KEY',
+           'RowNum,INVESTIGATION_KEY,CONDITION_KEY,PATIENT_KEY,INVESTIGATOR_KEY,PHYSICIAN_KEY,REPORTER_KEY,RPT_SRC_ORG_KEY,ADT_HSPTL_KEY,INV_ASSIGNED_DT_KEY,LDF_GROUP_KEY',
            1
        ),
        (
@@ -3877,7 +3877,7 @@ values
       WHERE RowNum BETWEEN :startRow AND :endRow;',
            'SELECT COUNT(*)
       FROM Covid_lab_datamart;',
-           'Covid_lab_datamart_KEY',
+           'COVID_LAB_DATAMART_KEY',
            'RowNum',
            1
        ),

--- a/DataCompareAPIs/src/main/resources/db/data_internal/routines/001-generate-data.sql
+++ b/DataCompareAPIs/src/main/resources/db/data_internal/routines/001-generate-data.sql
@@ -2475,10 +2475,12 @@ values
            'RDB_MODERN',
            'WITH PaginatedResults AS (
                                   SELECT DISTINCT MORBIDITY_REPORT.MORB_RPT_UID,
+								  INVESTIGATION.CASE_UID,
                                   MORBIDITY_REPORT_DATAMART.*,
                                          ROW_NUMBER() OVER (ORDER BY MORBIDITY_REPORT.MORB_RPT_UID ASC) AS RowNum
                                   FROM MORBIDITY_REPORT_DATAMART
                                   INNER JOIN MORBIDITY_REPORT ON MORBIDITY_REPORT.MORB_RPT_KEY = MORBIDITY_REPORT_DATAMART.MORBIDITY_REPORT_KEY
+								  LEFT JOIN INVESTIGATION ON INVESTIGATION.INVESTIGATION_KEY = MORBIDITY_REPORT_DATAMART.INVESTIGATION_KEY
                                )
                                SELECT *
                                FROM PaginatedResults
@@ -2486,7 +2488,7 @@ values
            'SELECT COUNT(*)
                                   FROM MORBIDITY_REPORT_DATAMART;',
            'MORB_RPT_UID',
-           'RowNum, MORBIDITY_REPORT_KEY',
+           'RowNum, MORBIDITY_REPORT_KEY, INVESTIGATION_KEY',
            1
        ),
        (


### PR DESCRIPTION
Minor updates to fix Data Compare results:

- Addition to Measles Case ignore list
- The key is case sensitive. If the case does not match, the dc results do not show up. 
Pre-update:

> {
>     "keyColumn": "Covid_lab_datamart_KEY",
>     "key": "NULL",
>     "table": "Covid_lab_datamart",
>     "missingColumn": "[]",
>     "nullValueColumns": "[]",
>     "differentColumnAndValue": "[Testing_lab_Address_Two: [SOURCE_VALUE:  ], [TARGET_VALUE: ],Address_Two: [SOURCE_VALUE:  ], [TARGET_VALUE: ],Ordering_Facility_Address_Two: [SOURCE_VALUE:  ], [TARGET_VALUE: null],Ordering_Provider_Address_Two: [SOURCE_VALUE:  ], [TARGET_VALUE: null],Ordering_Provider_Phone_Nbr: [SOURCE_VALUE: 701-640-5718], [TARGET_VALUE: null],Ordering_Provider_Phone_Ext: [SOURCE_VALUE: 0.0], [TARGET_VALUE: null]]"
>   }
> ]
> 

Post update:

> {
>     "keyColumn": "COVID_LAB_DATAMART_KEY",
>     "key": "13101295",
>     "table": "Covid_lab_datamart",
>     "missingColumn": "[]",
>     "nullValueColumns": "[]",
>     "differentColumnAndValue": "[Lab_Update_Dt: [SOURCE_VALUE: 2025-07-01 19:45:41.207], [TARGET_VALUE: 2025-06-02 19:22:59.990],Associated_Case_ID: [SOURCE_VALUE: CAS15681694GA01], [TARGET_VALUE: null]]"
>   }