### PR TITLE
APP-178 - Configure Dependabot to open PRs for dependency version upgrades, not just vulnerabilities

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,40 @@
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  # Enable version updates for Gradle
+  - package-ecosystem: "gradle"
+    directories:
+      - "/"
+      - "/DataCompareAPIs"
+      - "/DataCompareCron"
+      - "/DataCompareProcessor"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 2
+
+  # Enable version updates for Docker
+  - package-ecosystem: "docker"
+    directories:
+      - "/DataCompareAPIs"
+      - "/DataCompareProcessor"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 2
+
+  # Enable version updates for Docker Compose
+  - package-ecosystem: "docker-compose"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 2
+
+  # Enable version updates for GitHub Actions
+  - package-ecosystem: "github-actions"
+    # Workflow files stored in the default location of `.github/workflows`
+    # You don't need to specify `/.github/workflows` for `directory`. You can use `directory: "/"`.
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 2

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,9 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 2
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-patch"]
 
   # Enable version updates for Docker
   - package-ecosystem: "docker"
@@ -22,6 +25,9 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 2
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-patch"]
 
   # Enable version updates for Docker Compose
   - package-ecosystem: "docker-compose"
@@ -29,6 +35,9 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 2
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-patch"]
 
   # Enable version updates for GitHub Actions
   - package-ecosystem: "github-actions"
@@ -38,3 +47,6 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 2
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-patch"]


### PR DESCRIPTION
## Description

This PR adds a `dependabot.yml` file to the repo in order to configure Dependabot version updates for the following package ecosystems within this project:

- Docker
- Gradle
- GitHub Actions

## Tickets

* [Jira Ticket](https://cdc-nbs.atlassian.net/browse/APP-178)